### PR TITLE
Make creating and dropping databases safer with "if (not) exists" check

### DIFF
--- a/lib/lynx/d_s_l.rb
+++ b/lib/lynx/d_s_l.rb
@@ -21,11 +21,25 @@ module Lynx
         .sql("create database #{@config.database}")
     end
 
+    def create_database_if_not_exists
+      Command::Basic.new(@config)
+        .mysql
+        .authorize
+        .sql("create database if not exists #{@config.database}")
+    end
+
     def drop_database
       Command::Basic.new(@config)
         .mysql
         .authorize
         .sql("drop database #{@config.database}")
+    end
+
+    def drop_database_if_exists
+      Command::Basic.new(@config)
+        .mysql
+        .authorize
+        .sql("drop database if exists #{@config.database}")
     end
 
     def dump


### PR DESCRIPTION
[Background]
MySQL errors out if you try to create a table that already exists
or drop a table that does not exist.

[Changes]
This will make it so those operations are only attempted if a
database doesn't already exist in the case of creating, and if a
database does already exist in the case of dropping.

[Result]
Safer database creation and deletion