### PR TITLE
Ruby 3.2 Compatibility

### DIFF
--- a/lib/lynx.rb
+++ b/lib/lynx.rb
@@ -17,7 +17,7 @@ module Lynx
       if defined?(Rails)
         env ||= Rails.env
         hash = Rails.configuration.database_configuration
-      elsif File.exists?('config/database.yml')
+      elsif File.exist?('config/database.yml')
         hash = YAML::load(ERB.new(IO.read('config/database.yml')).result)
       else
         raise RuntimeError, 'unable to find configuration file'


### PR DESCRIPTION
Using this gem on Ruby 3.2 produces errors like the following:

```
~/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/lynx-1.1.0/lib/lynx.rb:20:in `rails': undefined method `exists?' for File:Class (NoMethodError)

      elsif File.exists?('config/database.yml')
                ^^^^^^^^
Did you mean?  exist?
```

`File.exists?` was deprecated in Ruby 2.2 and removed in Ruby 3.2.

 - https://www.reddit.com/r/ruby/comments/1196wti/psa_and_a_little_rant_fileexists_direxists/ 
 - https://github.com/ruby/ruby/pull/5352

Changing to `File.exist` fixes the problem.